### PR TITLE
Fix "RECENT POSTS" display errors

### DIFF
--- a/themes/huweihuang/layout/_widget/recent-posts.ejs
+++ b/themes/huweihuang/layout/_widget/recent-posts.ejs
@@ -1,5 +1,5 @@
 <% if (site.posts.length){ %>
-  <h5><%= __('RECENT POSTS') %></h3>
+  <h5><%= __('RECENT POSTS') %></h5>
   <div class="widget">
     <ul>
       <% site.posts.sort('date', -1).limit(5).each(function(post){ %>


### PR DESCRIPTION
Hi @huweihuang , 

Thanks for your contribution. I appreciate your effort and great talent of design.

### RECENT POSTS

I found there is one issue on RECENT POSTS since the closing tag for the title was mistakenly assigned as **h3** but starting with **h5**.

```ejs
<h5><%= __('RECENT POSTS') %></h3>
```

Therefore, the UI has a little bit out of formatted like this:

![image](https://user-images.githubusercontent.com/27748281/52458579-cd520680-2b25-11e9-858b-50c67df4aefa.png)

By changing the closing tag, we can fix this bug:

![image](https://user-images.githubusercontent.com/27748281/52458588-e8bd1180-2b25-11e9-9ec1-db93849521bc.png)

I am not sure if someone else has faced this issue either. 
Please help to make sure whether these changes are correct.

Thanks!

***

謝謝您對開源的貢獻，這是一個很棒的項目，也有著很漂亮的UI。
抓到一點小問題，希望日後能繼續參與優化，謝謝。

***
## Update 

### FEATURED TAGS

When I generated two different tags with each of them has only one article.

![image](https://user-images.githubusercontent.com/27748281/52459327-1dcb6300-2b2a-11e9-846e-9709e32e1882.png)

There are no tags displayed on the sidebar.

![image](https://user-images.githubusercontent.com/27748281/52459362-376caa80-2b2a-11e9-9c29-0de0d0298b5a.png)

After making this change to allow the tag with only `featured-condition-size` (1) also display on the sidebar, those two tags came back again!

![image](https://user-images.githubusercontent.com/27748281/52459385-6551ef00-2b2a-11e9-9bac-a2940fcea557.png)

***

不好意思，原本以為 FEATURE TAGS 沒有顯示出來，是自己設置出問題，
結果發現在 `featured-tags.ejs` 當中，原本預設

```ejs
 <% if(tag.length > config['featured-condition-size']) { %>
            <a href="<%= config.root %>tags/#<%= tag.name %>" title="<%= tag.name %>" rel="<%= tag.length %>"><%= tag.name %></a>
            <% } %>
```

會將只有一篇文章的tag給隱藏，改成 `>=` 之後，就能將所有生成的tags顯示在home page了。

***

Kevin
